### PR TITLE
SBT 0.13 Compatibility

### DIFF
--- a/project/DockerSeedPlugin.scala
+++ b/project/DockerSeedPlugin.scala
@@ -200,6 +200,10 @@ object DockerSeedPlugin extends AutoPlugin {
           .replaceAll("\\[slick_version]", getAttributeKey(desiredSlickVersion))
           .replaceAll("\\[sbt_version]", getAttributeKey(desiredSbtVersion))
           .replaceAll("\\[scala_version]", getAttributeKey(desiredScalaVersion))
+          .replaceAll("\\[caffeine]", getAttributeKey(desiredSbtVersion).split('.').headOption match {
+            case Some("0") => "" // do not add caffeine for sbt 0.x
+            case _ => "\n  caffeine,"
+          })
         printWriter.println(replacedLine)
       }
       printWriter.close()

--- a/project/placeholders/dependencies.sbt
+++ b/project/placeholders/dependencies.sbt
@@ -4,8 +4,7 @@ scalaVersion := "[scala_version]"
 libraryDependencies := Seq(
   ws,
   guice,
-  caffeine,
-  specs2 % Test,
+  specs2 % Test,[caffeine]
   "com.typesafe.play" %% "play-json" % "[play_version]",
   "com.typesafe.play" %% "play-slick" % "[slick_version]",
   "com.typesafe.play" %% "play-slick-evolutions" % "[slick_version]"


### PR DESCRIPTION
@ivanoronee 

I tried to use this seeder for one of the older projects that still uses SBT 0.13 and I ran into the following errors:
1). It looks like some classes in `sbt._` and `scala.sys.process._` have conflicting names. This can be solved by aliasing those classes.
```
Error while importing sbt project:

[info] Loading global plugins from /home/asrikin/.sbt/0.13/plugins
[info] Loading project definition from /home/asrikin/Tala/docker-play-seeder/project
[info] Compiling 1 Scala source to /home/asrikin/Tala/docker-play-seeder/project/target/scala-2.10/sbt-0.13/classes...
[error] /home/asrikin/Tala/docker-play-seeder/project/DockerSeedPlugin.scala:166: reference to ProcessLogger is ambiguous;
[error] it is imported twice in the same scope by
[error] import sbt._
[error] and import scala.sys.process._
[error]     val log: ProcessLogger = processLogger(state)
[error]              ^
[error] /home/asrikin/Tala/docker-play-seeder/project/DockerSeedPlugin.scala:237: reference to ProcessLogger is ambiguous;
[error] it is imported twice in the same scope by
[error] import sbt._
[error] and import scala.sys.process._
[error]   private def processLogger(st: State): ProcessLogger = new ProcessLogger {
[error]                                         ^
[error] /home/asrikin/Tala/docker-play-seeder/project/DockerSeedPlugin.scala:167: reference to ProcessBuilder is ambiguous;
[error] it is imported twice in the same scope by
[error] import sbt._
[error] and import scala.sys.process._
[error]     val process: ProcessBuilder = stringToProcess(s"docker build -t ${getDockerImageTag(state)} .")
[error]                  ^
[error] /home/asrikin/Tala/docker-play-seeder/project/DockerSeedPlugin.scala:167: reference to stringToProcess is ambiguous;
[error] it is imported twice in the same scope by
[error] import sbt._
[error] and import scala.sys.process._
[error]     val process: ProcessBuilder = stringToProcess(s"docker build -t ${getDockerImageTag(state)} .")
[error]                                   ^
[error] /home/asrikin/Tala/docker-play-seeder/project/DockerSeedPlugin.scala:174: reference to ProcessLogger is ambiguous;
[error] it is imported twice in the same scope by
[error] import sbt._
[error] and import scala.sys.process._
[error]     val log: ProcessLogger = processLogger(state)
[error]              ^
```

2). `play.sbt.caffeine` does not exists until SBT 1.x
```
Error while importing sbt project:

[info] Loading global plugins from /home/asrikin/.sbt/0.13/plugins
[info] Loading project definition from /home/asrikin/Tala/docker-play-seeder/project
/home/asrikin/Tala/docker-play-seeder/dependencies.sbt:7: error: not found: value caffeine
caffeine,
^
[error] Type error in expression
```

Of course, I could try upgrading the SBT versions of the old projects, but that comes with different sets of risks. Let me know your thoughts on this solution.

See [sample config](https://github.com/inventure/docker-play-seeder/compare/sbt-0.13-compatibility...sample-sbt-0.13-build?expand=1) I used to test out this change.


Test results on SBT 0.x and 1.x
![Screenshot from 2020-07-15 16-52-33](https://user-images.githubusercontent.com/5559568/87610984-bec53280-c6bb-11ea-94c9-a34f8992d54b.png)
![Screenshot from 2020-07-15 16-43-20](https://user-images.githubusercontent.com/5559568/87610985-bf5dc900-c6bb-11ea-93eb-a4c8ec1fbc9b.png)
