### PR TITLE
Activate Probot to close stale PRs and issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 5
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 1
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - do not merge
+  - help wanted
+  - illustration
+# Label to use when marking an issue as stale
+staleLabel: staled
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Solves problems associated with PRs being open for so long. I have noticed that this is a problem on this repo. PRs stay open for so long even after they have been reviewed. Some of the problems associated with PRs being open for so long includes
- Large merge conflicts
- Huge drift from what was initially reviewed and what is merged
- Bugs due to errors/mistakes in merge conflict resolution
- Bugs due to the introduction of new assumptions that did not take into consideration new changes being introduced in the PR that is open for so long