### PR TITLE
Install Git and create symlink for backward compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch-slim AS compile
 
 # Install ZIP and cURL
 RUN apt-get update && \
-    apt-get install -y zip unzip curl && \
+    apt-get install -y zip unzip curl git && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 

--- a/sbt-init.sh
+++ b/sbt-init.sh
@@ -6,6 +6,10 @@ source $HOME/.sdkman/bin/sdkman-init.sh
 sdk install java $(sdk list java | grep -o "8\.[0-9]*\.[0-9]*\.hs-adpt" | head -1)
 sdk install sbt
 
+# Create a symlink to /usr/bin so they can be used in plain sh
+ln -s $HOME/.sdkman/candidates/sbt/current/bin/sbt /usr/bin/sbt
+ln -s $HOME/.sdkman/candidates/java/current/bin/java /usr/bin/java
+
 # Remove temporary files
 rm -rf $HOME/.sdkman/archives/* && rm -rf $HOME/.sdkman/tmp/*
 


### PR DESCRIPTION
After swapping the base image in https://github.com/inventure/docker-play-seeder/pull/4, I found out that it breaks the backward compatibility for some projects because it does not contain `git` package. Also, SDKMAN does not automatically create the symlink to `/user/bin`. I added both and tested it one of the service:
![2021-03-10_14-49](https://user-images.githubusercontent.com/5559568/110709045-7c071c00-81b0-11eb-8791-a0b856c04ea2.png)
