### PR TITLE
Change name pattern for java sdks

### DIFF
--- a/sbt-init.sh
+++ b/sbt-init.sh
@@ -3,7 +3,7 @@
 source $HOME/.sdkman/bin/sdkman-init.sh
 
 # Install Java and SBT - Reference: https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
-sdk install java $(sdk list java | grep -o "8\.[0-9]*\.[0-9]*\.hs-adpt" | head -1)
+sdk install java $(sdk list java | grep -o "8\.[0-9]*\.[0-9]*-tem" | head -1)
 sdk install sbt
 
 # Create a symlink to /usr/bin so they can be used in plain sh


### PR DESCRIPTION
This looks to be the naming scheme in SDKMan for Temurin Java SDKs:
<img width="760" alt="image" src="https://user-images.githubusercontent.com/101892469/163876673-e9a3a600-af42-4bff-8b7c-df3b91c7333a.png">
