### PR TITLE
Set default Java version to Java 8 from OpenJDK

### DIFF
--- a/sbt-init.sh
+++ b/sbt-init.sh
@@ -3,7 +3,8 @@
 source $HOME/.sdkman/bin/sdkman-init.sh
 
 # Install Java and SBT - Reference: https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
-sdk install java $(sdk list java | grep -o "8\.[0-9]*\.[0-9]*\.hs-adpt" | head -1)
+# By default, it installs the latest version of Java 8 from OpenJDK (jdk.java.net)
+sdk install java $(sdk list java | grep -o "8\.[0-9]*\.[0-9]*-open" | head -1)
 sdk install sbt
 
 # Create a symlink to /usr/bin so they can be used in plain sh


### PR DESCRIPTION
While SBT recommends hs-adpt, this package is no longer available in SDKMAN. As a replacement, set the default JDK to `jdk.java.net` OpenJDK, which is the official reference implementation of Java SE since version 7.

Reference:
- https://sdkman.io/jdks
- https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
