### PR TITLE
Set static Java version to avoid pulling bad version

### DIFF
--- a/sbt-init.sh
+++ b/sbt-init.sh
@@ -4,7 +4,7 @@ source $HOME/.sdkman/bin/sdkman-init.sh
 
 # Install Java and SBT - Reference: https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
 # By default, it installs the latest version of Java 8 from OpenJDK (jdk.java.net)
-sdk install java $(sdk list java | grep -o "8\.[0-9]*\.[0-9]*-open" | head -1)
+sdk install java 8.0.302-open
 sdk install sbt
 
 # Create a symlink to /usr/bin so they can be used in plain sh


### PR DESCRIPTION
SDKMan repository sometimes contains bad image, causing error:

![2022-05-05_19-10](https://user-images.githubusercontent.com/5559568/167055313-3d0cf68e-e928-4e9a-ac95-b3feaf50c9ef.png)
