### PR TITLE
Move sdkman from /root to /usr/local/sdkman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     rm -rf /tmp/*
 
 # Download SDKMAN
+ENV SDKMAN_DIR="/usr/local/sdkman"
 RUN curl -s "https://get.sdkman.io" | bash
 
 # Define working directory

--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ Below are the various ways of generating images;
  s"$registry/play-dependencies-seed:$playVersion-sbt-$sbtVersion-scala-$scalaVersion-play-slick-$playSlickVersion"
  ```
 
+### Combining multiple images into a single multi-arch repository
+- Create images for each os/arch you wish to support with compatible machine
+  (e.g. use Intel machine to create amd64 image, Apple M1 machine to create arm64 image, etc)
+- Run the following command to combine the manifest
+  ```shell
+  docker manifest create targetName
+    --amend image1
+    --amend image2
+  ```
+  Example:
+  ```shell
+  docker manifest create tala/play-dependencies-seed:play-2.7.4-sbt-1.7.1-scala-2.12.15-play-slick-3.0.3-multi-arch
+    --amend alice/play-dependencies-seed:play-2.7.4-sbt-1.7.1-scala-2.12.15-play-slick-3.0.3-arm64
+    --amend sally/play-dependencies-seed:play-2.7.4-sbt-1.7.1-scala-2.12.15-play-slick-3.0.3-amd64
+  ```
+- Check the combined manifest
+  ``shell
+  docker manifest inspect tala/play-dependencies-seed:play-2.7.4-sbt-1.7.1-scala-2.12.15-play-slick-3.0.3-multi-arch
+  ``
+- Push the combined manifest
+  ``shell
+  docker manifest push tala/play-dependencies-seed:play-2.7.4-sbt-1.7.1-scala-2.12.15-play-slick-3.0.3-multi-arch
+  ``
+
 ### Note
 
 - When pushing to Dockerhub, the repository that will be pushed to is `[specified registry]/play-dependencies-seed`. If
@@ -86,28 +110,28 @@ permissions to create repositories in the account
 - This is the code related to multiple architecture for if we need to do so in the future.
 ```scala
 // The easy way to build multi-platform images. Still experimental enough it doesn't seem to work for us
-//val log: ProcessLogger = processLogger(state)
-//val process: ProcessBuilder = stringToProcess(s"docker buildx build --platform linux/arm64/v8,linux/amd64 -t ${getDockerImageTag(state)} .")
-//if (process ! log != 0) sys.error("Error building image")
+val log: ProcessLogger = processLogger(state)
+val process: ProcessBuilder = stringToProcess(s"docker buildx build --platform linux/arm64/v8,linux/amd64 -t ${getDockerImageTag(state)} .")
+if (process ! log != 0) sys.error("Error building image")
 
 //This is the harder way to build multi-platform images
-//val process1: ProcessBuilder = stringToProcess(s"docker build -t ${getDockerImageTag(state)}-manifest-amd64 --build-arg ARCH=amd64/ .")
-//if (process1 ! log != 0) sys.error("Error building amd64 image")
-//val process2: ProcessBuilder = stringToProcess(s"docker build -t ${getDockerImageTag(state)}-manifest-arm64v8 --build-arg ARCH=arm64v8/ .")
-//if (process2 ! log != 0) sys.error("Error building arm64v8 image")
+val process1: ProcessBuilder = stringToProcess(s"docker build -t ${getDockerImageTag(state)}-manifest-amd64 --build-arg ARCH=amd64/ .")
+if (process1 ! log != 0) sys.error("Error building amd64 image")
+val process2: ProcessBuilder = stringToProcess(s"docker build -t ${getDockerImageTag(state)}-manifest-arm64v8 --build-arg ARCH=arm64v8/ .")
+if (process2 ! log != 0) sys.error("Error building arm64v8 image")
 
-    //the code to combine cross platform images with a single manifest
-//    val log1: ProcessLogger = processLogger(state)
-//    val process1: ProcessBuilder = stringToProcess(s"docker push ${getDockerImageTag(state)}-manifest-amd64")
-//    if (process1 ! log1 != 0) sys.error("Error pushing amd64 docker image")
-//    val log2: ProcessLogger = processLogger(state)
-//    val process2: ProcessBuilder = stringToProcess(s"docker push ${getDockerImageTag(state)}-manifest-arm64v8")
-//    if (process2 ! log2 != 0) sys.error("Error pushing arm64v8 docker image")
-//    val log3: ProcessLogger = processLogger(state)
-//    val process3: ProcessBuilder = stringToProcess(s"docker manifest create ${getDockerImageTag(state)}-manifest-combined" +
-//      s"--amend ${getDockerImageTag(state)}-manifest-amd64 --amend ${getDockerImageTag(state)}-manifest-arm64v8")
-//    if (process3 ! log3 != 0) sys.error("Error creating cross platform manifest")
-//    val log4: ProcessLogger = processLogger(state)
-//    val process4: ProcessBuilder = stringToProcess(s"docker manifest push ${getDockerImageTag(state)}-manifest-combined")
-//    if (process4 ! log4 != 0) sys.error("Error pushing combined docker manifest")
+//the code to combine cross platform images with a single manifest
+val log1: ProcessLogger = processLogger(state)
+val process1: ProcessBuilder = stringToProcess(s"docker push ${getDockerImageTag(state)}-manifest-amd64")
+if (process1 ! log1 != 0) sys.error("Error pushing amd64 docker image")
+val log2: ProcessLogger = processLogger(state)
+val process2: ProcessBuilder = stringToProcess(s"docker push ${getDockerImageTag(state)}-manifest-arm64v8")
+if (process2 ! log2 != 0) sys.error("Error pushing arm64v8 docker image")
+val log3: ProcessLogger = processLogger(state)
+val process3: ProcessBuilder = stringToProcess(s"docker manifest create ${getDockerImageTag(state)}-manifest-combined" +
+  s"--amend ${getDockerImageTag(state)}-manifest-amd64 --amend ${getDockerImageTag(state)}-manifest-arm64v8")
+if (process3 ! log3 != 0) sys.error("Error creating cross platform manifest")
+val log4: ProcessLogger = processLogger(state)
+val process4: ProcessBuilder = stringToProcess(s"docker manifest push ${getDockerImageTag(state)}-manifest-combined")
+if (process4 ! log4 != 0) sys.error("Error pushing combined docker manifest")
 ```

--- a/sbt-init.sh
+++ b/sbt-init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/.sdkman/bin/sdkman-init.sh
+source $SDKMAN_DIR/bin/sdkman-init.sh
 
 # Install Java and SBT - Reference: https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
 # By default, it installs the latest version of Java 8 from OpenJDK (jdk.java.net)
@@ -8,11 +8,11 @@ sdk install java 8.0.342-amzn
 sdk install sbt 1.7.1
 
 # Create a symlink to /usr/bin so they can be used in plain sh
-ln -s $HOME/.sdkman/candidates/sbt/current/bin/sbt /usr/bin/sbt
-ln -s $HOME/.sdkman/candidates/java/current/bin/java /usr/bin/java
+ln -s $SDKMAN_DIR/candidates/sbt/current/bin/sbt /usr/bin/sbt
+ln -s $SDKMAN_DIR/candidates/java/current/bin/java /usr/bin/java
 
 # Remove temporary files
-rm -rf $HOME/.sdkman/archives/* && rm -rf $HOME/.sdkman/tmp/*
+rm -rf $SDKMAN_DIR/archives/* && rm -rf $SDKMAN_DIR/tmp/*
 
 # Pull all dependencies
 sbt clean update


### PR DESCRIPTION
Currently, sdkman and all packages installed using this tool are located under `/root` folder, which won't be accessible by non-root users. 

Additionally, I updated the README to include instructions on how to combine multiple manifests into a single repository.