### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@LawrenceAsrikin @Rapierian


### PR DESCRIPTION
Adding a CODEOWNERS file so the maintainers of this repository gets automatically tagged when a new PR is created.

See [reference](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).