### PR TITLE
Build SBT 1.9.1 image with debian:stable-20230522-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-20230612-slim AS compile
+FROM debian:stable-20230522-slim AS compile
 
 # Install ZIP and cURL
 RUN apt-get update && \


### PR DESCRIPTION
Revert the Debian image upgrade as it is causing the following Docker build issue
```
...
Step 10/23 : RUN sbt reload plugins
 ---> Running in 9ca72e5902db
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
copying runtime jar...
mkdir: cannot create directory '': No such file or directory
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Cannot create GC thread. Out of system resources.
# An error report file with more information is saved as:
# /var/srv/hs_err_pid56.log
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Cannot create GC thread. Out of system resources.
# An error report file with more information is saved as:
# /var/srv/hs_err_pid6.log
The command '/bin/sh -c sbt reload plugins' returned a non-zero code: 1
```
 