### PR TITLE
Allow users to specify base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stable-20230522-slim AS compile
+ARG BASE_IMAGE
+FROM $BASE_IMAGE AS compile
 
 # Install ZIP and cURL
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ You can use this project to generate Docker images containing cached versions of
 `sbt`, `scala`, and `java` deployed to a Docker registry of your choice — you must have permissions to push to the 
 specified Docker registry.
 
+#### Notes
+The Docker setup of this service is written and tested on Debian-based Linux distros (e.g. Debian, Ubuntu, Kali, etc.).
+If you wish to use this project with other distros, you might need to make small adjustments to the 
+[Dockerfile](Dockerfile), e.g. replacing `apt-get` with `yum` or `apk`, installing additional packages, etc.
+
 Below are the various ways of generating images:
 - Using default values specified in `project/versions.scala` file
   ```shell
@@ -36,6 +41,7 @@ Below are the various ways of generating images:
   [info] Loading settings for project root from dependencies.sbt,build.sbt ...
   [info] Set current project to play-docker-seeder (in build file:/Users/ivan/Code/env/inventure/apps/play-docker-seeder/)
   [info] ### Inquiring versions
+  Base Docker Image [debian:bullseye-20230725-slim] : debian:bullseye-20230725-slim
   Play! version [2.8.17] : 2.8.17
   play-json version [2.8.2] : 2.8.2
   Scala version [2.12.18] : 2.12.18
@@ -44,6 +50,7 @@ Below are the various ways of generating images:
   Sbt version [1.9.3] :
   Docker registry [ivanoronee] :
   [info] Working with versions:
+  [info] - base-image => debian:bullseye-20230725-slim
   [info] - play       => 2.8.17
   [info] - play-json  => 2.8.2
   [info] - scala      => 2.12.18
@@ -60,7 +67,7 @@ Below are the various ways of generating images:
   
 - Non interactive using custom values
   ```shell 
-  sbt "dockerSeed play-version 2.8.20 scala-version 2.12.18 java-version 17.0.4-amzn play-slick-version 3.0.4 sbt-version 1.9.3 docker-registry funkychicken" 
+  sbt "dockerSeed base-image debian:bullseye-20230725-slim play-version 2.8.20 scala-version 2.12.18 java-version 17.0.4-amzn play-slick-version 3.0.4 sbt-version 1.9.3 docker-registry funkychicken" 
   ```
   
  - Non interactive with some custom values and some default values
@@ -84,17 +91,17 @@ Below are the various ways of generating images:
   ```
   Example:
   ```shell
-  docker manifest create talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.4-java-8.0.382-amzn-multiarch
-    --amend alice/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.4-java-8.0.382-amzn-arm64
-    --amend sally/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.4-java-8.0.382-amzn-amd64
+  docker manifest create talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.4-java-8.0.382-amzn-debian-bullseye-20230725-slim-multiarch
+    --amend alice/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.4-java-8.0.382-amzn-debian-bullseye-20230725-slim-arm64
+    --amend sally/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.4-java-8.0.382-amzn-debian-bullseye-20230725-slim-amd64
   ```
 - Check the combined manifest
   ``shell
-  docker manifest inspect talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.3-java-8.0.382-amzn-multiarch
+  docker manifest inspect talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.3-java-8.0.382-amzn-debian-bullseye-20230725-slim-multiarch
   ``
 - Push the combined manifest
   ``shell
-  docker manifest push talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.3-java-8.0.382-amzn-multiarch
+  docker manifest push talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.3-scala-2.12.18-play-slick-3.0.3-java-8.0.382-amzn-debian-bullseye-20230725-slim-multiarch
   ``
 
 ### Notes

--- a/project/versions.scala
+++ b/project/versions.scala
@@ -1,4 +1,5 @@
 object versions {
+  val baseImage = "debian:stable-20230522-slim"
   val javaVersion = "8.0.382-amzn"
   val playVersion = "2.8.20"
   val playJsonVersion = "2.9.4"

--- a/project/versions.scala
+++ b/project/versions.scala
@@ -1,5 +1,5 @@
 object versions {
-  val baseImage = "debian:stable-20230522-slim"
+  val baseImage = "debian:bullseye-20230725-slim"
   val javaVersion = "8.0.382-amzn"
   val playVersion = "2.8.20"
   val playJsonVersion = "2.9.4"


### PR DESCRIPTION
This change allows users to specify the Docker Base Image, similar to other dependencies.

![2023-08-05_13-54](https://github.com/inventure/docker-play-seeder/assets/5559568/8c87b59b-be64-4f0f-a3df-6e73ead375e2)
