### PR TITLE
Load the same version of Play Framework in both dependencies.sbt and plugins.sbt

### DIFF
--- a/dependencies.sbt
+++ b/dependencies.sbt
@@ -5,3 +5,7 @@ libraryDependencies := Seq(
   "com.typesafe.play" %% "play-slick" % versions.playSlickVersion,
   "com.typesafe.play" %% "play-slick-evolutions" % versions.playSlickVersion
 )
+
+dependencyOverrides ++= Seq(
+  "com.typesafe.play" %% "play" % versions.playVersion
+)

--- a/project/placeholders/dependencies.sbt
+++ b/project/placeholders/dependencies.sbt
@@ -9,3 +9,10 @@ libraryDependencies := Seq(
 dependencyOverrides ++= Seq(
   "com.typesafe.play" %% "play" % "[play_version]"
 )
+
+// The selected version of the framework may contain packages with known vulnerabilities
+// Exclude the common ones from the base Docker image as they will be added back when compiling the application
+excludeDependencies ++= Seq(
+  ExclusionRule("com.fasterxml.jackson.core", "jackson-databind"),
+  ExclusionRule("com.google.guava", "guava")
+)

--- a/project/placeholders/dependencies.sbt
+++ b/project/placeholders/dependencies.sbt
@@ -5,3 +5,7 @@ libraryDependencies := Seq(
   "com.typesafe.play" %% "play-slick" % "[play_slick_version]",
   "com.typesafe.play" %% "play-slick-evolutions" % "[play_slick_version]"
 )
+
+dependencyOverrides ++= Seq(
+  "com.typesafe.play" %% "play" % "[play_version]"
+)


### PR DESCRIPTION
This change covers:
- Add Play Framework to dependencyOverrides
- Exclude packages with known CVEs when generating base image
