### PR TITLE
Exclude SBT plugin pakcages with CVEs

### DIFF
--- a/project/placeholders/plugins.sbt
+++ b/project/placeholders/plugins.sbt
@@ -2,3 +2,10 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "[play_version]")
 
 // Fix Scala XML compatibility issue when using SBT 1.8.x https://eed3si9n.com/sbt-1.8.0
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
+// The selected version of the framework may contain packages with known vulnerabilities
+// Exclude the common ones from the base Docker image as they will be added back when compiling the application
+ThisBuild / excludeDependencies ++= Seq(
+  ExclusionRule("org.apache.ant", "ant"),
+  ExclusionRule("org.apache.commons", "commons-compress")
+)


### PR DESCRIPTION
Similar to https://github.com/inventure/docker-play-seeder/pull/38, this cleans up SBT dependencies with known vulnerability.

Note: The zlib vulnerability will be fix as soon as Debian publishes the fix
![2023-10-24_13-37](https://github.com/inventure/docker-play-seeder/assets/5559568/a632f002-c9da-4248-a269-ed870f0f3d0e)
