### PR TITLE
Set default version of play-slick to 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Below are the various ways of generating images:
   Play! version [2.8.17] : 2.8.17
   Scala version [2.12.18] : 2.12.18
   Java version [17.0.4-amzn] : 17.0.4-amzn
-  Play-Slick version [3.0.4] :
+  Play-Slick version [5.1.0] :
   Sbt version [1.9.7] :
   Docker registry [ivanoronee] :
   [info] Working with versions:
@@ -53,7 +53,7 @@ Below are the various ways of generating images:
   [info] - play       => 2.8.17
   [info] - scala      => 2.12.18
   [info] - java       => 17.0.4-amzn
-  [info] - play-slick => 3.0.4
+  [info] - play-slick => 5.1.0
   [info] - sbt        => 1.9.7
   [info] - registry   => interruptingCow
   [info] ### Updating dependencies
@@ -65,12 +65,12 @@ Below are the various ways of generating images:
   
 - Non interactive using custom values
   ```shell 
-  sbt "dockerSeed base-image debian:bullseye-20231009-slim play-version 2.8.20 scala-version 2.12.18 java-version 17.0.4-amzn play-slick-version 3.0.4 sbt-version 1.9.7 docker-registry funkychicken" 
+  sbt "dockerSeed base-image debian:bullseye-20231009-slim play-version 2.8.20 scala-version 2.12.18 java-version 17.0.4-amzn play-slick-version 5.1.0 sbt-version 1.9.7 docker-registry funkychicken" 
   ```
   
  - Non interactive with some custom values and some default values
    ```shell 
-   sbt "dockerSeed with-defaults sbt-version 1.9.3 docker-registry monkeybusiness"
+   sbt "dockerSeed with-defaults sbt-version 1.9.7 docker-registry monkeybusiness"
    ``` 
    
  When the command returns, an image will be deployed to the specified docker registry. Below is the format of the image
@@ -89,17 +89,17 @@ Below are the various ways of generating images:
   ```
   Example:
   ```shell
-  docker manifest create talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-3.0.4-java-8.0.392-amzn-debian-bullseye-20231009-slim-multiarch
-    --amend alice/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-3.0.4-java-8.0.392-amzn-debian-bullseye-20231009-slim-arm64
-    --amend sally/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-3.0.4-java-8.0.392-amzn-debian-bullseye-20231009-slim-amd64
+  docker manifest create talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-5.1.0-java-8.0.392-amzn-debian-bullseye-20231009-slim-multiarch
+    --amend alice/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-5.1.0-java-8.0.392-amzn-debian-bullseye-20231009-slim-arm64
+    --amend sally/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-5.1.0-java-8.0.392-amzn-debian-bullseye-20231009-slim-amd64
   ```
 - Check the combined manifest
   ``shell
-  docker manifest inspect talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-3.0.3-java-8.0.392-amzn-debian-bullseye-20231009-slim-multiarch
+  docker manifest inspect talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-5.1.0-java-8.0.392-amzn-debian-bullseye-20231009-slim-multiarch
   ``
 - Push the combined manifest
   ``shell
-  docker manifest push talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-3.0.3-java-8.0.392-amzn-debian-bullseye-20231009-slim-multiarch
+  docker manifest push talaengineering/play-dependencies-seed:play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-5.1.0-java-8.0.392-amzn-debian-bullseye-20231009-slim-multiarch
   ``
 
 ### Notes

--- a/project/versions.scala
+++ b/project/versions.scala
@@ -2,7 +2,7 @@ object versions {
   val baseImage = "debian:bullseye-20231009-slim"
   val javaVersion = "8.0.392-amzn"
   val playVersion = "2.8.20"
-  val playSlickVersion = "3.0.4"
+  val playSlickVersion = "5.1.0"
   val scalaVersion = "2.12.18"
   val sbtVersion = "1.9.7" //make sure to also bump build.properties and sbt-init.sh
 }


### PR DESCRIPTION
I published the amd64 version to https://hub.docker.com/layers/talalawrenceasrikin/play-dependencies-seed/play-2.8.20-sbt-1.9.7-scala-2.12.18-play-slick-5.1.0-java-8.0.392-amzn-debian-bullseye-20231009-slim/images/sha256-205de98c0d26ce4ea272779aa2230e497a7d19e4117ffbdaa4727466535689d2