### PR TITLE
Updating sbt and docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,20 @@ Below are the various ways of generating images:
   [info] Loading settings for project root from dependencies.sbt,build.sbt ...
   [info] Set current project to play-docker-seeder (in build file:/Users/ivan/Code/env/inventure/apps/play-docker-seeder/)
   [info] ### Inquiring versions
-  Base Docker Image [debian:bullseye-20241111-slim] : debian:bullseye-20241111-slim
+  Base Docker Image [debian:bullseye-20241223-slim] : debian:bullseye-20241223-slim
   Play! version [2.9.6] : 2.9.6
   Scala version [2.13.15] : 2.13.15
   Java version [11.0.25-amzn] : 11.0.25-amzn
   Play-Slick version [5.3.1] :
-  Sbt version [1.10.6] :
+  Sbt version [1.10.7] :
   Docker registry [ivanoronee] :
   [info] Working with versions:
-  [info] - base-image => debian:bullseye-20241111-slim
+  [info] - base-image => debian:bullseye-20241223-slim
   [info] - play       => 2.9.6
   [info] - scala      => 2.13.15
   [info] - java       => 11.0.25-amzn
   [info] - play-slick => 5.3.1
-  [info] - sbt        => 1.10.6
+  [info] - sbt        => 1.10.7
   [info] - registry   => interruptingCow
   [info] ### Updating dependencies
   [info] ### Updating plugins
@@ -65,12 +65,12 @@ Below are the various ways of generating images:
   
 - Non interactive using custom values
   ```shell 
-  sbt "dockerSeed base-image debian:bullseye-20241111-slim play-version 2.9.6 scala-version 2.13.15 java-version 11.0.25-amzn play-slick-version 5.3.1 sbt-version 1.10.6 docker-registry funkychicken" 
+  sbt "dockerSeed base-image debian:bullseye-20241223-slim play-version 2.9.6 scala-version 2.13.15 java-version 11.0.25-amzn play-slick-version 5.3.1 sbt-version 1.10.7 docker-registry funkychicken" 
   ```
   
  - Non interactive with some custom values and some default values
    ```shell 
-   sbt "dockerSeed with-defaults sbt-version 1.10.6 docker-registry monkeybusiness"
+   sbt "dockerSeed with-defaults sbt-version 1.10.7 docker-registry monkeybusiness"
    ``` 
    
  When the command returns, an image will be deployed to the specified docker registry. Below is the format of the image
@@ -89,17 +89,17 @@ Below are the various ways of generating images:
   ```
   Example:
   ```shell
-  docker manifest create talaengineering/play-dependencies-seed:play-2.9.6-sbt-1.10.6-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241111-slim-multiarch
-    --amend alice/play-dependencies-seed:play-2.9.6-sbt-1.10.6-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241111-slim-arm64
-    --amend sally/play-dependencies-seed:play-2.9.6-sbt-1.10.6-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241111-slim-amd64
+  docker manifest create talaengineering/play-dependencies-seed:play-2.9.6-sbt-1.10.7-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241223-slim-multiarch
+    --amend alice/play-dependencies-seed:play-2.9.6-sbt-1.10.7-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241223-slim-arm64
+    --amend sally/play-dependencies-seed:play-2.9.6-sbt-1.10.7-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241223-slim-amd64
   ```
 - Check the combined manifest
   ``shell
-  docker manifest inspect talaengineering/play-dependencies-seed:play-2.9.4-sbt-1.10.6-scala-2.13.15-play-slick-5.3.1-java-11.0.23-amzn-debian-bullseye-20240701-slim-multiarch
+  docker manifest inspect talaengineering/play-dependencies-seed:play-2.9.4-sbt-1.10.7-scala-2.13.15-play-slick-5.3.1-java-11.0.23-amzn-debian-bullseye-20240701-slim-multiarch
   ``
 - Push the combined manifest
   ``shell
-  docker manifest push talaengineering/play-dependencies-seed:play-2.9.4-sbt-1.10.6-scala-2.13.15-play-slick-5.3.1-java-11.0.23-amzn-debian-bullseye-20240701-slim-multiarch
+  docker manifest push talaengineering/play-dependencies-seed:play-2.9.4-sbt-1.10.7-scala-2.13.15-play-slick-5.3.1-java-11.0.23-amzn-debian-bullseye-20240701-slim-multiarch
   ``
 
 ### Notes

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.6
+sbt.version=1.10.7

--- a/project/versions.scala
+++ b/project/versions.scala
@@ -1,8 +1,8 @@
 object versions {
-  val baseImage = "debian:bullseye-20241111-slim"
+  val baseImage = "debian:bullseye-20241223-slim"
   val javaVersion = "11.0.25-amzn"
   val playVersion = "2.9.6"
   val playSlickVersion = "5.3.1"
   val scalaVersion = "2.13.15"
-  val sbtVersion = "1.10.6" //make sure to also bump build.properties and sbt-init.sh
+  val sbtVersion = "1.10.7" //make sure to also bump build.properties and sbt-init.sh
 }

--- a/sbt-init.sh
+++ b/sbt-init.sh
@@ -5,7 +5,7 @@ source $SDKMAN_DIR/bin/sdkman-init.sh
 # Install Java and SBT - Reference: https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
 sdk update
 sdk install java 11.0.25-amzn
-sdk install sbt 1.10.6
+sdk install sbt 1.10.7
 
 # Create a symlink to /usr/bin so they can be used in plain sh
 ln -s $SDKMAN_DIR/candidates/sbt/current/bin/sbt /usr/bin/sbt


### PR DESCRIPTION
Updated sbt version and debian version. arm image here: https://hub.docker.com/layers/rapierian/play-dependencies-seed/play-2.9.6-sbt-1.10.7-scala-2.13.15-play-slick-5.3.1-java-11.0.25-amzn-debian-bullseye-20241223-slim/images/sha256-cf26122ecf54855a879adf97b00dfe6cda077085f12e5e08d1b4f1082bd6cc6e