### PR TITLE
Allow user to set custom image tag and add os.arch suffix to the default tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,29 @@ Below are the various ways of generating images:
   [info] Loading settings for project root from dependencies.sbt,build.sbt ...
   [info] Set current project to play-docker-seeder (in build file:/Users/ivan/Code/env/inventure/apps/play-docker-seeder/)
   [info] ### Inquiring versions
-  Base Docker Image [debian:bullseye-20250610-slim] : debian:bullseye-20250610-slim
-  Play! version [2.9.7] : 2.9.7
-  Scala version [2.13.16] : 2.13.16
-  Java version [21.0.7-amzn] : 21.0.7-amzn
+  Base Docker Image [debian:bullseye-20250610-slim] :
+  Play! version [2.9.7] :
+  Scala version [2.13.16] :
+  Java version [21.0.7-amzn] :
   Play-Slick version [5.4.0] :
   Sbt version [1.11.2] :
-  Docker registry [ivanoronee] :
+  Add os.arch suffix to image name (y/n) [y] :
+  Docker registry [talaengineering] : myregistry
+  Image tag (leave blank to use default) :
   [info] Working with versions:
-  [info] - base-image => debian:bullseye-20250610-slim
-  [info] - play       => 2.9.7
-  [info] - scala      => 2.13.16
-  [info] - java       => 21.0.7-amzn
-  [info] - play-slick => 5.4.0
-  [info] - sbt        => 1.11.2
-  [info] - registry   => interruptingCow
+  [info] - base-image       => debian:bullseye-20250610-slim
+  [info] - play             => 2.9.7
+  [info] - scala            => 2.13.16
+  [info] - java             => 21.0.7-amzn
+  [info] - play-slick       => 5.4.0
+  [info] - sbt              => 1.11.2
+  [info] - registry         => talalawrenceasrikin
+  [info] - custom image tag =>
   [info] ### Updating dependencies
   [info] ### Updating plugins
   [info] ### Updating build properties
-  [info] ### Building docker image
+  [info] ### Updating sbt-init.sh
+  [info] ### Building docker image for os.arch 'amd64'
   [info] Sending build context to Docker daemon  355.3kB
   ```
   
@@ -75,7 +79,7 @@ Below are the various ways of generating images:
    
  When the command returns, an image will be deployed to the specified docker registry. Below is the format of the image
  ``` 
- s"$registry/play-dependencies-seed:$playVersion-sbt-$sbtVersion-scala-$scalaVersion-play-slick-$playSlickVersion-java-$javaVersion"
+ s"$registry/play-dependencies-seed:$playVersion-sbt-$sbtVersion-scala-$scalaVersion-play-slick-$playSlickVersion-java-$javaVersion-$osArch"
  ```
 
 ### Combining multiple images into a single multiarch repository
@@ -90,7 +94,7 @@ Below are the various ways of generating images:
   Example:
   ```shell
   docker manifest create talaengineering/play-dependencies-seed:play-2.9.7-sbt-1.11.2-scala-2.13.16-play-slick-5.4.0-java-21.0.7-amzn-debian-bullseye-20250407-slim-multiarch
-    --amend alice/play-dependencies-seed:play-2.9.7-sbt-1.11.2-scala-2.13.16-play-slick-5.4.0-java-21.0.7-amzn-debian-bullseye-20250407-slim-arm64
+    --amend alice/play-dependencies-seed:play-2.9.7-sbt-1.11.2-scala-2.13.16-play-slick-5.4.0-java-21.0.7-amzn-debian-bullseye-20250407-slim-aarch64
     --amend sally/play-dependencies-seed:play-2.9.7-sbt-1.11.2-scala-2.13.16-play-slick-5.4.0-java-21.0.7-amzn-debian-bullseye-20250407-slim-amd64
   ```
 - Check the combined manifest

--- a/project/DockerSeedPlugin.scala
+++ b/project/DockerSeedPlugin.scala
@@ -312,7 +312,6 @@ object DockerSeedPlugin extends AutoPlugin {
     val customTag = getAttributeKey(desiredDockerImageTag).trim
     val imageTag = if (customTag.isBlank) defaultTag else customTag
 
-
     s"$registry/play-dependencies-seed:$imageTag"
   }
 

--- a/project/DockerSeedPlugin.scala
+++ b/project/DockerSeedPlugin.scala
@@ -4,9 +4,9 @@ import scala.io.Source
 import scala.sys.process.{ProcessBuilder, ProcessLogger, stringToProcess}
 import scala.util.{Failure, Try}
 
-import sbt.Keys._
-import sbt._
-import sbt.complete.DefaultParsers._
+import sbt.*
+import sbt.Keys.*
+import sbt.complete.DefaultParsers.*
 import sbt.complete.Parser
 
 object DockerSeedPlugin extends AutoPlugin {
@@ -124,10 +124,12 @@ object DockerSeedPlugin extends AutoPlugin {
 
   }
 
-  import autoImport.DockerSeedKeys._
+  import autoImport.DockerSeedKeys.*
+
+  private val osArch: Option[String] = Option(System.getProperty("os.arch"))
 
   private val inquireVersions = { state: State =>
-    import versions._
+    import versions.*
     state.log.info("### Inquiring versions")
     val useDefs = state.get(useDefaults).getOrElse(false)
     val base = readVersion(baseImage, "Base Docker Image [%s] : ", useDefs, state.get(commandLineBaseImage).flatten)
@@ -201,7 +203,7 @@ object DockerSeedPlugin extends AutoPlugin {
   }
 
   private val runDockerBuild = { state: State =>
-    state.log.info("### Building docker image")
+    state.log.info(s"### Building docker image for os.arch '${osArch.mkString}'")
     val log: ProcessLogger = processLogger(state)
     val imageTag: String = getDockerImageTag(state)
     val imageName: String = getAttributeKey(desiredBaseImage)(state)
@@ -265,6 +267,16 @@ object DockerSeedPlugin extends AutoPlugin {
     val scalaVersion = getAttributeKey(desiredScalaVersion)
     val javaVersion = getAttributeKey(desiredJavaVersion)
     val registry = getAttributeKey(desiredDockerRegistry)
+
+    Seq(
+      Some(s"play-$playVersion"),
+      Some(s"sbt-$sbtVersion"),
+      Some(s"scala-$scalaVersion"),
+      Some(s"play-slick-$playSlickVersion"),
+      Some(s"java-$javaVersion"),
+      Some(s"$baseImage"),
+      osArch
+    ).flatten.mkString("-")
 
     s"$registry/play-dependencies-seed:" +
       s"play-$playVersion-" +


### PR DESCRIPTION
Using auto-generated tag name (with os.arch suffix by default)
![2025-06-12_14-54](https://github.com/user-attachments/assets/43f73503-67cf-463e-b3db-abbc98406fcc)
![2025-06-12_14-54_1](https://github.com/user-attachments/assets/cdfd15c2-11c7-4021-b9e5-92a3f5829c09)

Using auto-generated tag name (without os.arch suffix)
![2025-06-12_14-57](https://github.com/user-attachments/assets/23e7b809-0abb-4eb4-a3aa-db3950991eb7)
![2025-06-12_15-00](https://github.com/user-attachments/assets/31c9ff8e-f24a-4515-8c56-cf006d543cd1)

Using custom tag name
![2025-06-12_16-02](https://github.com/user-attachments/assets/de251170-a714-4475-983a-a71a8c48287f)
![2025-06-12_16-02_1](https://github.com/user-attachments/assets/224e00bc-d4ad-4363-b450-fc458aed9268)
