### PR TITLE
Add publish-seed-image GitHub Action and Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,85 @@
+# Copilot Instructions
+
+## Purpose
+
+This tool generates Docker "seed" images that pre-cache Play! framework (Scala) dependencies to drastically speed up
+Docker build times for Play! applications (~10x improvement). It is an SBT project whose only output is a Docker image
+pushed to a registry.
+
+## Commands
+
+```shell
+# Interactive (prompts for each version)
+sbt dockerSeed
+
+# Use all defaults from project/versions.scala and project/docker.scala
+sbt "dockerSeed with-defaults"
+
+# Non-interactive with explicit values
+sbt "dockerSeed base-image debian:bullseye-20260421-slim play-version 3.0.10 scala-version 2.13.18 java-version 21.0.11-amzn play-slick-version 6.2.0 sbt-version 1.12.11 docker-registry myregistry"
+
+# Mix: use defaults but override specific values
+sbt "dockerSeed with-defaults sbt-version 1.12.11 docker-registry myregistry"
+```
+
+There are no automated tests in this project.
+
+## Architecture
+
+The core logic lives in `project/DockerSeedPlugin.scala` — an SBT `AutoPlugin` that registers the `dockerSeed` command.
+When run, it executes this pipeline in sequence:
+
+1. **`inquireVersions`** — Collects versions interactively, from CLI args, or from defaults in
+   `project/versions.scala` / `project/docker.scala`
+2. **`updateDependencies`** — Renders `project/placeholders/dependencies.sbt` → `dependencies.sbt`
+3. **`updatePlugins`** — Renders `project/placeholders/plugins.sbt` → `project/plugins.sbt`
+4. **`updateBuildProperties`** — Renders `project/placeholders/build.properties` → `project/build.properties`
+5. **`updateSbtInit`** — Renders `project/placeholders/sbt-init.sh` → `sbt-init.sh`
+6. **`runDockerBuild`** — Runs `docker build --provenance=false -t <tag> --build-arg BASE_IMAGE=<image> .`
+7. **`runDockerPublish`** — Runs `docker push <tag>`
+8. **`resetDependencies`** — Runs `git reset --hard HEAD` to restore modified files
+
+The `Dockerfile` uses SDKMAN to install Java and SBT, then runs `sbt clean update` (via `sbt-init.sh`) to pull and cache
+all dependencies into the image layer.
+
+## Key Conventions
+
+### Placeholder syntax
+
+Files under `project/placeholders/` use `[token]` syntax for version substitution:
+
+- `[play_version]`, `[scala_version]`, `[java_version]`, `[sbt_version]`, `[play_slick_version]`
+
+These are the canonical templates; the root-level `dependencies.sbt`, `sbt-init.sh`, `project/plugins.sbt`, and
+`project/build.properties` are generated files that get reset after each build.
+
+### Default versions
+
+All defaults live in two files:
+
+- `project/versions.scala` — component versions (Play, Scala, Java, SBT, play-slick, base image)
+- `project/docker.scala` — default Docker registry (`changeme`)
+
+### Image tag format
+
+```
+$registry/play-dependencies-seed:play-$playVersion-sbt-$sbtVersion-scala-$scalaVersion-play-slick-$playSlickVersion-java-$javaVersion-$baseImage[-$osArch]
+```
+
+The `os.arch` suffix is appended when `add-os-suffix` is `y`/`yes` (default). Use this to build arch-specific images 
+(e.g., `amd64`, `aarch64`) before combining into a multiarch manifest.
+
+### Play plugin version alignment
+
+The `sbt-plugin` version in `project/placeholders/plugins.sbt` (and the checked-in `project/plugins.sbt`) must stay in
+sync with the Play version in `project/versions.scala`. There is a comment in `project/plugins.sbt` as a reminder.
+
+### Dockerfile is Debian-specific
+
+The `Dockerfile` uses `apt-get`. For non-Debian distros, replace with `yum` or `apk` as needed.
+
+### Vulnerability exclusions
+
+The placeholder `dependencies.sbt` and `plugins.sbt` intentionally exclude known-vulnerable transitive dependencies 
+(`jackson-databind`, `guava`, `ant`, `commons-compress`, `protobuf-java`). These are expected to be re-added by the
+consuming application's own dependency declarations.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,18 @@ sbt "dockerSeed base-image debian:bullseye-20260421-slim play-version 3.0.10 sca
 
 # Mix: use defaults but override specific values
 sbt "dockerSeed with-defaults sbt-version 1.12.11 docker-registry myregistry"
+
+# Build the image locally without pushing (skip publish)
+sbt "dockerSeed with-defaults skip-publish"
+
+# Override the generated image tag entirely
+sbt "dockerSeed with-defaults docker-registry myregistry image-tag my-custom-tag"
+
+# Build without the os.arch suffix
+sbt "dockerSeed with-defaults docker-registry myregistry add-os-suffix n"
 ```
+
+The working directory must have a clean git state for non-placeholder files — `resetDependencies` runs `git reset --hard HEAD` at the end to restore generated files.
 
 There are no automated tests in this project.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ sbt "dockerSeed with-defaults docker-registry myregistry image-tag my-custom-tag
 sbt "dockerSeed with-defaults docker-registry myregistry add-os-suffix n"
 ```
 
-The working directory must have a clean git state for non-placeholder files — `resetDependencies` runs `git reset --hard HEAD` at the end to restore generated files.
+The working directory must have a clean git state for non-placeholder files — `resetDependencies` runs `git reset --hard HEAD` at the end to restore generated files. **Always commit your changes before running `dockerSeed`**, or they will be lost.
 
 There are no automated tests in this project.
 

--- a/.github/workflows/build-seed-image.yml
+++ b/.github/workflows/build-seed-image.yml
@@ -1,0 +1,42 @@
+name: Build Seed Image
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Build amd64 image
+        run: sbt "dockerSeed with-defaults skip-publish"
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Build arm64 image
+        run: sbt "dockerSeed with-defaults skip-publish"

--- a/.github/workflows/build-seed-image.yml
+++ b/.github/workflows/build-seed-image.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build-amd64:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -58,15 +58,22 @@ jobs:
 
       - name: Create and push multiarch manifest
         run: |
-          REGISTRY="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
+          PRIVATE_REGISTRY="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
+          PUBLIC_REGISTRY="${{ secrets.DOCKERHUB_PUBLIC_REGISTRY }}"
           BASE_IMAGE=$(grep 'val baseImage' project/versions.scala | sed 's/.*"\(.*\)".*/\1/' | tr ':' '-')
           PLAY=$(grep 'val playVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
           SBT_VER=$(grep 'val sbtVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
           SCALA=$(grep 'val scalaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
           SLICK=$(grep 'val playSlickVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
           JAVA=$(grep 'val javaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          BASE_TAG="${REGISTRY}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}"
-          docker manifest create ${BASE_TAG}-multiarch \
-            --amend ${BASE_TAG}-amd64 \
-            --amend ${BASE_TAG}-aarch64
-          docker manifest push ${BASE_TAG}-multiarch
+          PRIVATE_BASE="${PRIVATE_REGISTRY}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}"
+          MULTIARCH_TAG="${PUBLIC_REGISTRY}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}-multiarch"
+          docker manifest create ${MULTIARCH_TAG} \
+            --amend ${PRIVATE_BASE}-amd64 \
+            --amend ${PRIVATE_BASE}-aarch64
+          PUSH_OUTPUT=$(docker manifest push ${MULTIARCH_TAG} 2>&1) && echo "$PUSH_OUTPUT" || {
+            echo "$PUSH_OUTPUT"
+            echo "$PUSH_OUTPUT" | grep -qi "denied\|already exists\|immutable\|tag invalid\|400\|409" \
+              && echo "Image already exists in public registry — skipping (expected for immutable tags)" \
+              || (echo "Unexpected error pushing manifest" && exit 1)
+          }

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  build-amd64:
     runs-on: ubuntu-latest
-
+    outputs:
+      image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -23,5 +24,67 @@ jobs:
       - name: Log in to DockerHub
         run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Build and publish seed image
+      - name: Compute image tag
+        id: image-tag
+        run: |
+          BASE_IMAGE=$(grep 'val baseImage' project/versions.scala | sed 's/.*"\(.*\)".*/\1/' | tr ':' '-')
+          PLAY=$(grep 'val playVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SBT_VER=$(grep 'val sbtVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SCALA=$(grep 'val scalaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SLICK=$(grep 'val playSlickVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          JAVA=$(grep 'val javaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          TAG="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}-amd64"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Build and publish amd64 image
         run: sbt "dockerSeed with-defaults docker-registry ${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      image-tag: ${{ steps.image-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Log in to DockerHub
+        run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Compute image tag
+        id: image-tag
+        run: |
+          BASE_IMAGE=$(grep 'val baseImage' project/versions.scala | sed 's/.*"\(.*\)".*/\1/' | tr ':' '-')
+          PLAY=$(grep 'val playVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SBT_VER=$(grep 'val sbtVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SCALA=$(grep 'val scalaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SLICK=$(grep 'val playSlickVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          JAVA=$(grep 'val javaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          TAG="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}-aarch64"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Build and publish arm64 image
+        run: sbt "dockerSeed with-defaults docker-registry ${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
+
+  publish-multiarch:
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to DockerHub
+        run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Create and push multiarch manifest
+        run: |
+          AMD64_TAG="${{ needs.build-amd64.outputs.image-tag }}"
+          ARM64_TAG="${{ needs.build-arm64.outputs.image-tag }}"
+          MULTIARCH_TAG="${AMD64_TAG%-amd64}-multiarch"
+          docker manifest create $MULTIARCH_TAG --amend $AMD64_TAG --amend $ARM64_TAG
+          docker manifest push $MULTIARCH_TAG

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -1,0 +1,27 @@
+name: Publish Seed Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: amazon-corretto
+          java-version: 21
+
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Log in to DockerHub
+        run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Build and publish seed image
+        run: sbt "dockerSeed with-defaults docker-registry ${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -2,6 +2,15 @@ name: Publish Seed Image
 
 on:
   workflow_dispatch:
+    branches:
+      - master
+
+concurrency:
+  group: publish-seed-image
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   build-amd64:

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: amazon-corretto
+          distribution: corretto
           java-version: 21
 
       - name: Set up SBT

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: corretto
           java-version: 21

--- a/.github/workflows/publish-seed-image.yml
+++ b/.github/workflows/publish-seed-image.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   build-amd64:
     runs-on: ubuntu-latest
-    outputs:
-      image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -23,26 +21,12 @@ jobs:
 
       - name: Log in to DockerHub
         run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-      - name: Compute image tag
-        id: image-tag
-        run: |
-          BASE_IMAGE=$(grep 'val baseImage' project/versions.scala | sed 's/.*"\(.*\)".*/\1/' | tr ':' '-')
-          PLAY=$(grep 'val playVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          SBT_VER=$(grep 'val sbtVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          SCALA=$(grep 'val scalaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          SLICK=$(grep 'val playSlickVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          JAVA=$(grep 'val javaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          TAG="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}-amd64"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Build and publish amd64 image
         run: sbt "dockerSeed with-defaults docker-registry ${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
-    outputs:
-      image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -58,18 +42,6 @@ jobs:
 
       - name: Log in to DockerHub
         run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-      - name: Compute image tag
-        id: image-tag
-        run: |
-          BASE_IMAGE=$(grep 'val baseImage' project/versions.scala | sed 's/.*"\(.*\)".*/\1/' | tr ':' '-')
-          PLAY=$(grep 'val playVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          SBT_VER=$(grep 'val sbtVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          SCALA=$(grep 'val scalaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          SLICK=$(grep 'val playSlickVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          JAVA=$(grep 'val javaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
-          TAG="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}-aarch64"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Build and publish arm64 image
         run: sbt "dockerSeed with-defaults docker-registry ${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
@@ -78,13 +50,23 @@ jobs:
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Log in to DockerHub
         run: docker login -u${{ secrets.DOCKERHUB_USERNAME }} -p${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Create and push multiarch manifest
         run: |
-          AMD64_TAG="${{ needs.build-amd64.outputs.image-tag }}"
-          ARM64_TAG="${{ needs.build-arm64.outputs.image-tag }}"
-          MULTIARCH_TAG="${AMD64_TAG%-amd64}-multiarch"
-          docker manifest create $MULTIARCH_TAG --amend $AMD64_TAG --amend $ARM64_TAG
-          docker manifest push $MULTIARCH_TAG
+          REGISTRY="${{ secrets.DOCKERHUB_PRIVATE_REGISTRY }}"
+          BASE_IMAGE=$(grep 'val baseImage' project/versions.scala | sed 's/.*"\(.*\)".*/\1/' | tr ':' '-')
+          PLAY=$(grep 'val playVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SBT_VER=$(grep 'val sbtVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SCALA=$(grep 'val scalaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          SLICK=$(grep 'val playSlickVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          JAVA=$(grep 'val javaVersion' project/versions.scala | sed 's/.*"\(.*\)".*/\1/')
+          BASE_TAG="${REGISTRY}/play-dependencies-seed:play-${PLAY}-sbt-${SBT_VER}-scala-${SCALA}-play-slick-${SLICK}-java-${JAVA}-${BASE_IMAGE}"
+          docker manifest create ${BASE_TAG}-multiarch \
+            --amend ${BASE_TAG}-amd64 \
+            --amend ${BASE_TAG}-aarch64
+          docker manifest push ${BASE_TAG}-multiarch

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@paulou @AnandChokshi @LawrenceAsrikin @meguignard-tala @Rapierian
+* @inventure/scala-common-libs-maintainers

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Below are the various ways of generating images:
   ``` 
   $ sbt dockerSeed
   [info] Loading settings for project global-plugins from idea.sbt ...
-  [info] Loading global plugins from /Users/ivan/.sbt/1.0/plugins
+  [info] Loading global plugins from /Users/alice/.sbt/1.0/plugins
   [info] Loading settings for project play-docker-seeder-build from plugins.sbt ...
-  [info] Loading project definition from /Users/ivan/Code/env/inventure/apps/play-docker-seeder/project
+  [info] Loading project definition from /Users/alice/Code/env/inventure/apps/play-docker-seeder/project
   [info] Loading settings for project root from dependencies.sbt,build.sbt ...
-  [info] Set current project to play-docker-seeder (in build file:/Users/ivan/Code/env/inventure/apps/play-docker-seeder/)
+  [info] Set current project to play-docker-seeder (in build file:/Users/alice/Code/env/inventure/apps/play-docker-seeder/)
   [info] ### Inquiring versions
   Base Docker Image [debian:bullseye-20260421-slim] :
   Play! version [3.0.10] :
@@ -48,7 +48,7 @@ Below are the various ways of generating images:
   Play-Slick version [6.2.0] :
   Sbt version [1.12.11] :
   Add os.arch suffix to image name (y/n) [y] :
-  Docker registry [talaengineering] : myregistry
+  Docker registry [changeme] : myregistry
   Image tag (leave blank to use default) :
   [info] Working with versions:
   [info] - base-image       => debian:bullseye-20260421-slim
@@ -57,7 +57,7 @@ Below are the various ways of generating images:
   [info] - java             => 21.0.11-amzn
   [info] - play-slick       => 6.2.0
   [info] - sbt              => 1.12.11
-  [info] - registry         => talalawrenceasrikin
+  [info] - registry         => myregistry
   [info] - custom image tag =>
   [info] ### Updating dependencies
   [info] ### Updating plugins
@@ -93,17 +93,17 @@ Below are the various ways of generating images:
   ```
   Example:
   ```shell
-  docker manifest create talaengineering/play-dependencies-seed:play-3.0.10-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-multiarch
+  docker manifest create myregistry/play-dependencies-seed:play-3.0.10-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-multiarch
     --amend alice/play-dependencies-seed:play-3.0.10-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-aarch64
     --amend sally/play-dependencies-seed:play-3.0.10-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-amd64
   ```
 - Check the combined manifest
   ``shell
-  docker manifest inspect talaengineering/play-dependencies-seed:play-2.9.4-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-multiarch
+  docker manifest inspect myregistry/play-dependencies-seed:play-2.9.4-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-multiarch
   ``
 - Push the combined manifest
   ``shell
-  docker manifest push talaengineering/play-dependencies-seed:play-2.9.4-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-multiarch
+  docker manifest push myregistry/play-dependencies-seed:play-2.9.4-sbt-1.12.11-scala-2.13.18-play-slick-6.2.0-java-21.0.11-amzn-debian-bullseye-20260421-slim-multiarch
   ``
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ Below are the various ways of generating images:
    ```shell 
    sbt "dockerSeed with-defaults sbt-version 1.12.11 docker-registry monkeybusiness"
    ``` 
-   
+
+ - Build the image locally without pushing (dry run)
+   ```shell
+   sbt "dockerSeed with-defaults skip-publish"
+   ```
+
  When the command returns, an image will be deployed to the specified docker registry. Below is the format of the image
  ``` 
  s"$registry/play-dependencies-seed:$playVersion-sbt-$sbtVersion-scala-$scalaVersion-play-slick-$playSlickVersion-java-$javaVersion-$osArch"

--- a/project/DockerSeedPlugin.scala
+++ b/project/DockerSeedPlugin.scala
@@ -85,6 +85,9 @@ object DockerSeedPlugin extends AutoPlugin {
       private[this] val WithDefaults: Parser[ParseResult] =
         (Space ~> token("with-defaults")) ^^^ ParseResult.WithDefaults
 
+      private[this] val SkipPublish: Parser[ParseResult] =
+        (Space ~> token("skip-publish")) ^^^ ParseResult.SkipPublish
+
       private[this] object ParseResult {
 
         final case class BaseImage(value: String) extends ParseResult
@@ -107,6 +110,8 @@ object DockerSeedPlugin extends AutoPlugin {
 
         case object WithDefaults extends ParseResult
 
+        case object SkipPublish extends ParseResult
+
       }
 
       private[this] val dockerSeedParser: Parser[Seq[ParseResult]] = (
@@ -116,6 +121,7 @@ object DockerSeedPlugin extends AutoPlugin {
           | PlayVersion
           | playSlickVersion
           | WithDefaults
+          | SkipPublish
           | SbtVersion
           | AddOsSuffix
           | DockerRegistry
@@ -123,6 +129,8 @@ object DockerSeedPlugin extends AutoPlugin {
         ).*
 
       val dockerSeedCommand: Command = Command(dockerSeedCommandKey)(_ => dockerSeedParser) { (st, args) =>
+        val skipPublishing = args.contains(ParseResult.SkipPublish)
+
         val startState: State = st
           .put(useDefaults, args.contains(ParseResult.WithDefaults))
           .put(commandLineBaseImage, args.collectFirst { case ParseResult.BaseImage(value) => value })
@@ -135,11 +143,12 @@ object DockerSeedPlugin extends AutoPlugin {
           .put(commandLineDockerRegistry, args.collectFirst { case ParseResult.DockerRegistry(value) => value })
           .put(commandLineImageTag, args.collectFirst { case ParseResult.ImageTag(value) => value })
 
+        val publishStep = if (skipPublishing) Seq.empty else Seq(runDockerPublish)
+
         Function.chain(
-          Seq(
-            inquireVersions, updateDependencies, updatePlugins, updateBuildProperties, updateSbtInit, runDockerBuild,
-            runDockerPublish, resetDependencies
-          )
+          Seq(inquireVersions, updateDependencies, updatePlugins, updateBuildProperties, updateSbtInit, runDockerBuild)
+            ++ publishStep
+            ++ Seq(resetDependencies)
         )(startState)
       }
     }
@@ -238,6 +247,7 @@ object DockerSeedPlugin extends AutoPlugin {
     val imageName: String = getAttributeKey(desiredBaseImage)(state)
     val process: ProcessBuilder = stringToProcess(s"docker build --provenance=false -t $imageTag --build-arg BASE_IMAGE=$imageName .")
     if (process ! log != 0) sys.error("Error building image")
+    state.log.info(s"### Docker image built: $imageTag")
     state
   }
 

--- a/project/docker.scala
+++ b/project/docker.scala
@@ -1,3 +1,3 @@
 object docker {
-  val registry = "talaengineering"
+  val registry = "changeme"
 }


### PR DESCRIPTION
## Changes

### `.github/workflows/publish-seed-image.yml`
- Manual `workflow_dispatch` trigger (runs from any branch)
- Sets up Amazon Corretto 21 + SBT via `sbt/setup-sbt@v1`
- Logs into DockerHub using `DOCKERHUB_USERNAME` and `DOCKERHUB_ACCESS_TOKEN` secrets
- Runs `sbt "dockerSeed with-defaults docker-registry $DOCKERHUB_PRIVATE_REGISTRY"` to build and push the seed image with all version defaults from `project/versions.scala`

### `.github/copilot-instructions.md`
- Documents build commands, architecture, and key conventions for future Copilot sessions


<img width="1525" height="729" alt="2026-05-24_17-01" src="https://github.com/user-attachments/assets/e51f447c-800b-48c2-b95f-eef9049f1764" />
