### PR TITLE
Add skip-publish flag and build-only CI workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,18 @@ sbt "dockerSeed base-image debian:bullseye-20260421-slim play-version 3.0.10 sca
 
 # Mix: use defaults but override specific values
 sbt "dockerSeed with-defaults sbt-version 1.12.11 docker-registry myregistry"
+
+# Build the image locally without pushing (skip publish)
+sbt "dockerSeed with-defaults skip-publish"
+
+# Override the generated image tag entirely
+sbt "dockerSeed with-defaults docker-registry myregistry image-tag my-custom-tag"
+
+# Build without the os.arch suffix
+sbt "dockerSeed with-defaults docker-registry myregistry add-os-suffix n"
 ```
+
+The working directory must have a clean git state for non-placeholder files — `resetDependencies` runs `git reset --hard HEAD` at the end to restore generated files.
 
 There are no automated tests in this project.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ sbt "dockerSeed with-defaults docker-registry myregistry image-tag my-custom-tag
 sbt "dockerSeed with-defaults docker-registry myregistry add-os-suffix n"
 ```
 
-The working directory must have a clean git state for non-placeholder files — `resetDependencies` runs `git reset --hard HEAD` at the end to restore generated files.
+The working directory must have a clean git state for non-placeholder files — `resetDependencies` runs `git reset --hard HEAD` at the end to restore generated files. **Always commit your changes before running `dockerSeed`**, or they will be lost.
 
 There are no automated tests in this project.
 

--- a/.github/workflows/build-seed-image.yml
+++ b/.github/workflows/build-seed-image.yml
@@ -1,0 +1,42 @@
+name: Build Seed Image
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Build amd64 image
+        run: sbt "dockerSeed with-defaults skip-publish"
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: Build arm64 image
+        run: sbt "dockerSeed with-defaults skip-publish"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ Below are the various ways of generating images:
    ```shell 
    sbt "dockerSeed with-defaults sbt-version 1.12.11 docker-registry monkeybusiness"
    ``` 
-   
+
+ - Build the image locally without pushing (dry run)
+   ```shell
+   sbt "dockerSeed with-defaults skip-publish"
+   ```
+
  When the command returns, an image will be deployed to the specified docker registry. Below is the format of the image
  ``` 
  s"$registry/play-dependencies-seed:$playVersion-sbt-$sbtVersion-scala-$scalaVersion-play-slick-$playSlickVersion-java-$javaVersion-$osArch"

--- a/project/DockerSeedPlugin.scala
+++ b/project/DockerSeedPlugin.scala
@@ -85,6 +85,9 @@ object DockerSeedPlugin extends AutoPlugin {
       private[this] val WithDefaults: Parser[ParseResult] =
         (Space ~> token("with-defaults")) ^^^ ParseResult.WithDefaults
 
+      private[this] val SkipPublish: Parser[ParseResult] =
+        (Space ~> token("skip-publish")) ^^^ ParseResult.SkipPublish
+
       private[this] object ParseResult {
 
         final case class BaseImage(value: String) extends ParseResult
@@ -107,6 +110,8 @@ object DockerSeedPlugin extends AutoPlugin {
 
         case object WithDefaults extends ParseResult
 
+        case object SkipPublish extends ParseResult
+
       }
 
       private[this] val dockerSeedParser: Parser[Seq[ParseResult]] = (
@@ -116,6 +121,7 @@ object DockerSeedPlugin extends AutoPlugin {
           | PlayVersion
           | playSlickVersion
           | WithDefaults
+          | SkipPublish
           | SbtVersion
           | AddOsSuffix
           | DockerRegistry
@@ -123,6 +129,8 @@ object DockerSeedPlugin extends AutoPlugin {
         ).*
 
       val dockerSeedCommand: Command = Command(dockerSeedCommandKey)(_ => dockerSeedParser) { (st, args) =>
+        val skipPublishing = args.contains(ParseResult.SkipPublish)
+
         val startState: State = st
           .put(useDefaults, args.contains(ParseResult.WithDefaults))
           .put(commandLineBaseImage, args.collectFirst { case ParseResult.BaseImage(value) => value })
@@ -135,11 +143,12 @@ object DockerSeedPlugin extends AutoPlugin {
           .put(commandLineDockerRegistry, args.collectFirst { case ParseResult.DockerRegistry(value) => value })
           .put(commandLineImageTag, args.collectFirst { case ParseResult.ImageTag(value) => value })
 
+        val publishStep = if (skipPublishing) Seq.empty else Seq(runDockerPublish)
+
         Function.chain(
-          Seq(
-            inquireVersions, updateDependencies, updatePlugins, updateBuildProperties, updateSbtInit, runDockerBuild,
-            runDockerPublish, resetDependencies
-          )
+          Seq(inquireVersions, updateDependencies, updatePlugins, updateBuildProperties, updateSbtInit, runDockerBuild)
+            ++ publishStep
+            ++ Seq(resetDependencies)
         )(startState)
       }
     }
@@ -238,6 +247,7 @@ object DockerSeedPlugin extends AutoPlugin {
     val imageName: String = getAttributeKey(desiredBaseImage)(state)
     val process: ProcessBuilder = stringToProcess(s"docker build --provenance=false -t $imageTag --build-arg BASE_IMAGE=$imageName .")
     if (process ! log != 0) sys.error("Error building image")
+    state.log.info(s"### Docker image built: $imageTag")
     state
   }
 


### PR DESCRIPTION
## Summary

Adds a `skip-publish` flag to `dockerSeed` and a new GitHub Actions workflow that uses it for PR validation.

### Changes

**`project/DockerSeedPlugin.scala`**
- New `skip-publish` flag (no-value, same pattern as `with-defaults`): when present, `runDockerPublish` is excluded from the pipeline
- Added a confirmation log line after a successful `docker build`

**`.github/workflows/build-seed-image.yml`**
- Triggers on `pull_request` and `workflow_dispatch`
- Two parallel jobs: `build-amd64` (`ubuntu-latest`) and `build-arm64` (`ubuntu-24.04-arm`)
- Uses `sbt "dockerSeed with-defaults skip-publish"` — no Docker login, no push, no manifest step

**`.github/copilot-instructions.md`**
- Documents `skip-publish`, `image-tag`, `add-os-suffix` command examples
- Notes git working tree requirement
- Documents the two-registry CI/CD pattern